### PR TITLE
Add update task description feature with unit tests

### DIFF
--- a/TaskTracker.Tests/Services/TaskServiceTest.cs
+++ b/TaskTracker.Tests/Services/TaskServiceTest.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using TaskTracker.Models;
 using TaskTracker.Repositories;
 using TaskTracker.Services;
@@ -65,5 +66,64 @@ public class TaskServiceTests : TestBase
 
         Assert.Single(doneTasks);
         Assert.Equal(TaskItemStatus.Done, doneTasks[0].Status);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_UpdatesTaskDescription()
+    {
+        // Arrange
+        var service = CreateService();
+
+        var createdTask = await service.AddTaskAsync("Initial project");
+
+        // Act
+        var updatedTask = await service.UpdateTaskDescriptionAsync(
+            createdTask.Id,
+            "update project");
+
+        // Assert
+        Assert.Equal(createdTask.Id, updatedTask.Id);
+        Assert.Equal("update project", updatedTask.Description);
+        Assert.True(updatedTask.UpdatedAt > createdTask.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_Throws_WhenIdIsZero()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => service.UpdateTaskDescriptionAsync(0, "update project"));
+
+        Assert.Contains("id", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_Throws_WhenDescriptionIsEmpty()
+    {
+        // Arrange
+        var service = CreateService();
+        var task = await service.AddTaskAsync("Initial project");
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => service.UpdateTaskDescriptionAsync(task.Id, "   "));
+
+        Assert.Contains("description", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateTaskAsync_Throws_WhenTaskDoesNotExist()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.UpdateTaskDescriptionAsync(999, "update project"));
+
+        Assert.Contains("not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/TaskTracker/Program.cs
+++ b/TaskTracker/Program.cs
@@ -50,6 +50,19 @@ try
             break;
         }
 
+        case "update":
+        {
+            EnsureArgs(args, 3, "update \"id\" \"task description\"");
+
+            if (!int.TryParse(args[1], out int idTask))
+                throw new ArgumentException("Task id must be a number.");
+
+            var updatedTask = await service.UpdateTaskAsync(idTask, args[2]);
+
+            Console.WriteLine($"Task updated successfully (ID: {updatedTask.Id})");
+            break;
+        }
+
         default:
             Console.WriteLine("Unknown command.");
             ShowHelp();

--- a/TaskTracker/Program.cs
+++ b/TaskTracker/Program.cs
@@ -57,7 +57,7 @@ try
             if (!int.TryParse(args[1], out int idTask))
                 throw new ArgumentException("Task id must be a number.");
 
-            var updatedTask = await service.UpdateTaskAsync(idTask, args[2]);
+            var updatedTask = await service.UpdateTaskDescriptionAsync(idTask, args[2]);
 
             Console.WriteLine($"Task updated successfully (ID: {updatedTask.Id})");
             break;

--- a/TaskTracker/Services/TaskService.cs
+++ b/TaskTracker/Services/TaskService.cs
@@ -42,7 +42,7 @@ public class TaskService
             : tasks.Where(t => t.Status == status).ToList();
     }
 
-    public async Task<TaskItem> UpdateTaskAsync(int id, string description)
+    public async Task<TaskItem> UpdateTaskDescriptionAsync(int id, string description)
     {
         if (id <= 0)
             throw new ArgumentException("Task id must be greater than zero.");

--- a/TaskTracker/Services/TaskService.cs
+++ b/TaskTracker/Services/TaskService.cs
@@ -41,4 +41,27 @@ public class TaskService
             ? tasks
             : tasks.Where(t => t.Status == status).ToList();
     }
+
+    public async Task<TaskItem> UpdateTaskAsync(int id, string description)
+    {
+        if (id <= 0)
+            throw new ArgumentException("Task id must be greater than zero.");
+
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Task description cannot be empty.");
+
+        var tasks = await _repository.LoadAsync();
+
+        var task = tasks.FirstOrDefault(t => t.Id == id);
+
+        if (task is null)
+            throw new InvalidOperationException($"Task with id {id} not found.");
+
+        task.Description = description.Trim();
+        task.UpdatedAt = DateTime.UtcNow;
+
+        await _repository.SaveAsync(tasks);
+
+        return task;
+    }
 }


### PR DESCRIPTION
## What was done

- Added the ability to update a task description by task ID
- Implemented validation to ensure:
  - Task ID is greater than zero
  - Task description is not empty
  - Task to be updated exists
- Persisted updated task data to the JSON repository
- Added unit tests covering:
  - Successful task description update
  - Invalid task ID
  - Empty task description
  - Updating a non-existent task

## Why

Updating an existing task is a core feature of the task tracker.
Input validation and unit tests ensure the update behavior is reliable
and prevents regressions.

## How to test

1. Run unit tests:
   ```bash
   dotnet test

2. Run the CLI manually:
   ```bash
   dotnet run update <id> "new task description"